### PR TITLE
No need to get all table to count table size

### DIFF
--- a/src/Http/Controllers/ResourcesController.php
+++ b/src/Http/Controllers/ResourcesController.php
@@ -17,7 +17,7 @@ class ResourcesController
 
         $items = [];
         foreach ($availableResources as $resource) {
-            $count = $resource::$model::all()->count();
+            $count = $resource::$model::count();
             $label = $count === 1 ? $resource::singularLabel() : $resource::label();
             $items[$resource] = [
                 'count' => $count,


### PR DESCRIPTION
When you use all() its executing different query which is not useful for counting table rows...